### PR TITLE
Feature/show layer description

### DIFF
--- a/src/views/components/map/sidebar-layer/AddLayers.vue
+++ b/src/views/components/map/sidebar-layer/AddLayers.vue
@@ -30,6 +30,37 @@
                     {{ name }}
                   </el-tag>
                 </p>
+                <!--Create a button that says "Mostrar Descrição" that when i click it displays the description-->
+                <!-- <p>
+                  <strong>{{ $t('map.addLayer.box.lbDescription') }}:</strong>
+                  <span v-if="layer.properties.description != null">
+                    {{ layer.properties.description }}
+                  </span>
+                  <span v-else>
+                    {{ $t('map.addLayer.box.lbNoDescription') }}
+                  </span>
+                </p> -->
+                <p>
+                  <span v-if="layer.properties.description != null && showDescription[layer.properties.layer_id]">
+                    <strong>{{ $t('map.addLayer.box.lbDescription') }}:</strong>
+                    {{ layer.properties.description }}
+                    <div class="btns">
+                      <el-button @click="toggleDescription(layer.properties.layer_id)">
+                        {{ $t('map.addLayer.box.lbShowLess') }}
+                      </el-button>
+                    </div>
+                  </span>
+                  <span v-else-if="layer.properties.description != null">
+                    <div class="btns">
+                      <el-button @click="toggleDescription(layer.properties.layer_id)">
+                        {{ $t('map.addLayer.box.lbShowMore') }}
+                      </el-button>
+                    </div>
+                  </span>
+                  <span v-else>
+                    {{ $t('map.addLayer.box.lbNoDescription') }}
+                  </span>
+                </p>
               </div>
 
               <div class="btns">
@@ -88,7 +119,8 @@ export default {
         listLayers: [],
         allLayers: [],
         allKeywords: [],
-        allAuthorsLayers: []
+        allAuthorsLayers: [],
+        showDescription: {}
       }
     },
     async mounted() {
@@ -131,6 +163,7 @@ export default {
         this.listLayers = this.allLayers
 
       } catch (error) {
+        console.log(error)
         this.$alert(this.$t('map.addLayer.msg.errMsg'), this.$t('map.addLayer.msg.errTitle'), {
           confirmButtonText: 'OK',
           type: 'error'
@@ -207,6 +240,13 @@ export default {
           spinner: 'el-icon-loading',
           background: 'rgba(0, 0, 0, 0.7)'
         })
+      },
+      toggleDescription(id) {
+        if (this.showDescription[id] === undefined) {
+          this.$set(this.showDescription, id, true);
+        } else {
+          this.showDescription[id] = !this.showDescription[id];
+        }
       }
     }
 }

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -282,7 +282,10 @@ export default {
             "box": {
                 "lbTitle": "TITLE",
                 "lbAuthors": "AUTHORS",
-                "lbKeywods": "KEYWORDS"
+                "lbKeywods": "KEYWORDS",
+                "lbDescription": "DESCRIPTION",
+                "lbShowMore": "Show more",
+                "lbShowLess": "Show less",
             },
             "btns": {
                 "active": "Active",

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -283,11 +283,14 @@ export default {
             "box": {
                 "lbTitle": "TÍTULO",
                 "lbAuthors": "AUTORES",
-                "lbKeywods": "PALAVRAS-CHAVE"
+                "lbKeywods": "PALAVRAS-CHAVE",
+                "lbDescription": "DESCRIÇÃO",
+                "lbShowMore": "Mostrar mais",
+                "lbShowLess": "Mostrar menos",
             },
             "btns": {
                 "active": "Ativar",
-                "disable": "Desativar"
+                "disable": "Desativar",
             },
             "msg": {
                 "errTitle": "Erro Interno",


### PR DESCRIPTION
# Opção de ver a descrição da camada antes de inserir no mapa

Hoje, em produção, quando o usuário segue para inserir uma camada no mapa, ele não consegue visualizar a descrição dessa camada, de modo que isso possa orientá-lo melhor sobre o que aquela camada se trata e se de fato é essa que ele gostaria de inserir na visualização.

# Descrição da solução

Para resolver esse problema, adicionamos um botão, logo abaixo das informações da camada, chamado “Mostrar Mais”. Ao clicar nesse botão, é exibida a descrição da camada e um novo botão é exibido, chamado “Mostrar menos”, que ao ser clicado minimiza a visualização das informações da camada e esconde a descrição, conforme exibido no vídeo. Para validar a solução foi desenvolvido um teste de aceitação, inserido no artefato 1 e com funcionamento exibido no vídeo.

# Elementos Técnicos

Foi criado um parágrafo na seção em que é exibida as informações das camadas a serem inseridas no mapa. Nesse parágrafo, é configurado para inicialmente exibir botões para deixar como opcional a visualização da descrição da camada. Quando o usuário clica no botão, um método chamado "toggleDescription" é acionado, no qual o atributo "showDescription", da camada em que o botão foi clicado, recebe o valor de verdadeiro. Dessa forma, a descrição é mostrada e um botão "Mostrar Menos" passa a ser exibido, e que do mesmo modo, quando clicado, configura o atributo como falso e então a descrição é escondida.

### Parágrafo onde é exibido o botão e descrição

```
                <p>
                  <span v-if="layer.properties.description != null && showDescription[layer.properties.layer_id]">
                    <strong>{{ $t('map.addLayer.box.lbDescription') }}:</strong>
                    {{ layer.properties.description }}
                    <div class="btns">
                      <el-button @click="toggleDescription(layer.properties.layer_id)">
                        {{ $t('map.addLayer.box.lbShowLess') }}
                      </el-button>
                    </div>
                  </span>
                  <span v-else-if="layer.properties.description != null">
                    <div class="btns">
                      <el-button @click="toggleDescription(layer.properties.layer_id)">
                        {{ $t('map.addLayer.box.lbShowMore') }}
                      </el-button>
                    </div>
                  </span>
                  <span v-else>
                    {{ $t('map.addLayer.box.lbNoDescription') }}
                  </span>
                </p>
```

### Definição do atributo

```
showDescription: {}
``` 

### Função para mudança no valor do atributo

```
toggleDescription(id) {
        if (this.showDescription[id] === undefined) {
          this.$set(this.showDescription, id, true);
        } else {
          this.showDescription[id] = !this.showDescription[id];
        }
}
```

# Testes de aceitação

Foi desenvolvido um teste de aceitação para assegurar o funcionamento da nova feature e a integridade e funcionamento dos demais componentes do código. O teste foi criado no arquivo expand_layer_description.feature seguindo os passos definidos abaixo. A configuração da execução dos passos foi feita com o cucumber e a execução com o selenium. O teste e a definição dos steps podem ser acessados no repositório do artefato 1, clicando neste [link](https://github.com/LuanGuilherme/artefato_1_ESI).

```
Feature: Show layer description before apply to map
    Scenario: Show layer description
        Given I am on the Pauliceia 2.0 home page
        When I follow Mapa
        And I click Camadas
        And click on the layers controll
        And it displays a list of layers
        And I click on the "Mostrar Mais" button
        Then I should see the layer description
        When I click on the "Mostrar Menos" button
        Then I should not see the layer description
```

# Considerações Finais

Utilizamos a metodologia ágil para implementar as demandas solicitadas, escolhidas pelo grupo. Na última semana do prazo final, adotamos o formato de reuniões diárias para acompanhamento e evolução das atividades. Cada dupla compartilhava o progresso, os desafios e as previsões relacionadas à demanda que estava sendo desenvolvida. Isso permitiu que todos os membros ficassem cientes do que estava sendo desenvolvido e colaborassem na resolução de problemas enfrentados por outras duplas. A dinâmica do grupo fluía bem, todos os membros estavam engajados nas demandas e não enfrentamos problemas em relação à distribuição de tarefas. 
Como técnica de Engenharia de Software, optamos por utilizar BDD em vez de TDD. Essa escolha foi motivada pela versão antiga do Node no projeto. Utilizamos o Cucumber para criar testes automatizados com base nos cenários descritos. Com essa abordagem, garantimos uma cobertura abrangente de testes e a integridade do código desenvolvido.