### PR TITLE
Correção do bug da mensagem de conflito de nomes ao criar uma nova camada

### DIFF
--- a/src/views/pages/dashboard/newLayer.vue
+++ b/src/views/pages/dashboard/newLayer.vue
@@ -611,7 +611,10 @@
               this.finished = 1
               this.loading.close();
 
-              this._showErrorMessages(cause)
+              if(cause.response.status === 409)
+                this._msgError("Já existe uma camada com esse nome, por favor, escolha outro!")
+              else
+                this._msgError("Erro ao criar a camada, confira as informações inseridas. Caso o erro persista entre em contato com os administradores da plataforma!")
             })
 
           } catch (error) {


### PR DESCRIPTION
Quando criava-se uma camada com o nome de uma camada já existente, a API do WGIWS retorna um status 409, que significa conflito por já existir uma camada com o nome inserido pelo usuário. Porém, a mensagem de erro retornada pela interface de usuário era "<html><title>409: Conflict</title><body>409: Conflict</body></html>". Com esta correção, a mensagem exibida passa ser "Já existe uma camada com esse nome, por favor, escolha outro!".

A correção foi feita na captura de erro na chamada de 'api/layer/create'

Testes de aceitação para essa feature foram incluídos no seguinte repositório https://github.com/LuanGuilherme/artefato_1_ESI 