### PR TITLE
Validação das datas da camada, sendo que a data de início não pode ser maior que a data final e a data final é limitada pelo ano corrente

### DIFF
--- a/src/views/pages/dashboard/editLayer.vue
+++ b/src/views/pages/dashboard/editLayer.vue
@@ -288,9 +288,32 @@
       },
       Upload2(){
         // this method sends the temporal columns to VGIMWS
-
         if ((this.startDate === "" || this.endDate === "") || (this.startDate === null || this.endDate === null)) {
           this._msgError("O preenchimento das datas é obrigatório!")
+          return;
+        }
+        
+        var startDateObject = new Date(Date.UTC(
+            parseInt(this.startDate.substring(0, 4), 10),
+            parseInt(this.startDate.substring(5, 7), 10) - 1,
+            parseInt(this.startDate.substring(8, 10), 10)
+        ));
+        
+        var endDateObject = new Date(Date.UTC(
+            parseInt(this.endDate.substring(0, 4), 10),
+            parseInt(this.endDate.substring(5, 7), 10) - 1,
+            parseInt(this.endDate.substring(8, 10), 10)
+        ));
+
+        var currentDate = new Date();
+
+        if(startDateObject > endDateObject){
+          this._msgError(`A data inicial não pode ser maior que a data final!`);
+          return;          
+        }
+
+        if(endDateObject.getUTCFullYear() > currentDate.getUTCFullYear()){
+          this._msgError(`O ano da data final da camada deve ser no máximo ${currentDate.getFullYear()}!`);
           return;
         }
 

--- a/src/views/pages/dashboard/newLayer.vue
+++ b/src/views/pages/dashboard/newLayer.vue
@@ -449,8 +449,32 @@
       Upload2(){  // cadastrar a segunda parte da camada - temporal columns
         this._openFullLoading()
 
-        if ((this.startDate === null || this.endDate === null) || (this.startDate === "" || this.endDate === "")) {
+        if ((this.startDate === "" || this.endDate === "") || (this.startDate === null || this.endDate === null)) {
           this._msgError("O preenchimento das datas é obrigatório!")
+          return;
+        }
+        
+        var startDateObject = new Date(Date.UTC(
+            parseInt(this.startDate.substring(0, 4), 10),
+            parseInt(this.startDate.substring(5, 7), 10) - 1,
+            parseInt(this.startDate.substring(8, 10), 10)
+        ));
+        
+        var endDateObject = new Date(Date.UTC(
+            parseInt(this.endDate.substring(0, 4), 10),
+            parseInt(this.endDate.substring(5, 7), 10) - 1,
+            parseInt(this.endDate.substring(8, 10), 10)
+        ));
+
+        var currentDate = new Date();
+
+        if(startDateObject > endDateObject){
+          this._msgError(`A data inicial não pode ser maior que a data final!`);
+          return;          
+        }
+
+        if(endDateObject.getUTCFullYear() > currentDate.getUTCFullYear()){
+          this._msgError(`O ano da data final da camada deve ser no máximo ${currentDate.getFullYear()}!`);
           return;
         }
 


### PR DESCRIPTION
Em produção, na criação ou edição de uma camada, é possível inserir uma data fim maior do que a do ano atual. Na nossa contribuição, é realizada uma validação para impedir que sejam criadas camadas com data fim maiores do que o ano atual. Outra contribuição é que antes era possível inserir camadas com a data inicial sendo maior que a final, esta contribuição contempla essa correção também.

Testes de aceitação para essa feature foram incluídos no seguinte repositório https://github.com/LuanGuilherme/artefato_1_ESI